### PR TITLE
refactor(states): return err on getting or setting a state

### DIFF
--- a/examples/registration/main.go
+++ b/examples/registration/main.go
@@ -66,7 +66,11 @@ func main() {
 	manager.Bind("/cancel", fsm.AnyState, OnCancelForm(regBtn))
 
 	manager.Bind("/state", fsm.AnyState, func(c tele.Context, state fsm.Context) error {
-		return c.Send(state.State().String())
+		s, err := state.State()
+		if err != nil {
+			return c.Send(fmt.Sprintf("can't get state: %s", err))
+		}
+		return c.Send(s.String())
 	})
 
 	// buttons

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -39,7 +40,11 @@ func main() {
 	// It also for any states. Because manager don't filter this handler
 	bot.Handle("/state",
 		m.HandlerAdapter(func(c tele.Context, state fsm.Context) error {
-			return c.Send("your state: " + state.State().String())
+			s, err := state.State()
+			if err != nil {
+				return c.Send(fmt.Sprintf("can't get state: %s", err))
+			}
+			return c.Send("your state: " + s.String())
 		}),
 	)
 

--- a/filters.go
+++ b/filters.go
@@ -25,7 +25,11 @@ func (m *Manager) ForState(want State, handler Handler) tele.HandlerFunc {
 // for current state to check for presence in given states.
 func (m *Manager) ForStates(h Handler, states ...State) tele.HandlerFunc {
 	return m.HandlerAdapter(func(c tele.Context, state Context) error {
-		if ContainsState(state.State(), states...) {
+		s, err := state.State()
+		if err != nil {
+			return err
+		}
+		if ContainsState(s, states...) {
 			return h(c, state)
 		}
 		return nil

--- a/filters.go
+++ b/filters.go
@@ -1,6 +1,9 @@
 package fsm
 
-import tele "gopkg.in/telebot.v3"
+import (
+	"github.com/pkg/errors"
+	tele "gopkg.in/telebot.v3"
+)
 
 // Filter object. Needs for graceful works with state filters.
 type Filter struct {
@@ -27,7 +30,7 @@ func (m *Manager) ForStates(h Handler, states ...State) tele.HandlerFunc {
 	return m.HandlerAdapter(func(c tele.Context, state Context) error {
 		s, err := state.State()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "fsm-telebot: get state in Manager.ForStates")
 		}
 		if ContainsState(s, states...) {
 			return h(c, state)

--- a/fsm_context.go
+++ b/fsm_context.go
@@ -10,10 +10,10 @@ type Context interface {
 	Bot() *tele.Bot
 
 	// State returns current state for sender.
-	State() State
+	State() (State, error)
 
 	// Set state for sender.
-	Set(state State)
+	Set(state State) error
 
 	// Finish state for sender and deletes data if set true.
 	Finish(deleteData bool) error
@@ -48,12 +48,12 @@ func (f *fsmContext) Bot() *tele.Bot {
 	return f.c.Bot()
 }
 
-func (f *fsmContext) State() State {
+func (f *fsmContext) State() (State, error) {
 	return f.s.GetState(f.chat, f.user)
 }
 
-func (f *fsmContext) Set(state State) {
-	f.s.SetState(f.chat, f.user, state)
+func (f *fsmContext) Set(state State) error {
+	return f.s.SetState(f.chat, f.user, state)
 }
 
 func (f *fsmContext) Finish(deleteData bool) error {

--- a/manager.go
+++ b/manager.go
@@ -1,6 +1,7 @@
 package fsm
 
 import (
+	"github.com/pkg/errors"
 	tele "gopkg.in/telebot.v3"
 )
 
@@ -105,7 +106,7 @@ func (m handlerStorage) getHandler(endpoint string) Handler {
 	return func(c tele.Context, fsm Context) error {
 		state, err := fsm.State()
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "fsm-telebot: get state for endpoint %s", endpoint)
 		}
 
 		for _, group := range m[endpoint] {

--- a/manager.go
+++ b/manager.go
@@ -82,13 +82,13 @@ func (m *Manager) Storage() Storage {
 }
 
 // GetState returns state for given user in given chat.
-func (m *Manager) GetState(chat, user int64) State {
+func (m *Manager) GetState(chat, user int64) (State, error) {
 	return m.s.GetState(chat, user)
 }
 
 // SetState sets state for given user in given chat.
-func (m *Manager) SetState(chat, user int64, state State) {
-	m.s.SetState(chat, user, state)
+func (m *Manager) SetState(chat, user int64, state State) error {
+	return m.s.SetState(chat, user, state)
 }
 
 // add handler to storage, just shortcut.
@@ -103,7 +103,11 @@ func (m handlerStorage) add(endpoint string, h Handler, states []State) {
 // getHandler returns handler what filters queries and execute correct handler.
 func (m handlerStorage) getHandler(endpoint string) Handler {
 	return func(c tele.Context, fsm Context) error {
-		state := fsm.State()
+		state, err := fsm.State()
+		if err != nil {
+			return err
+		}
+
 		for _, group := range m[endpoint] {
 			if ContainsState(state, group.states...) {
 				return group.handler(c, fsm)

--- a/middleware/state_filter.go
+++ b/middleware/state_filter.go
@@ -11,7 +11,10 @@ import (
 func StateFilterMiddleware(storage fsm.Storage, want fsm.State) tele.MiddlewareFunc {
 	return func(next tele.HandlerFunc) tele.HandlerFunc {
 		return func(c tele.Context) error {
-			currentState := storage.GetState(c.Chat().ID, c.Sender().ID)
+			currentState, err := storage.GetState(c.Chat().ID, c.Sender().ID)
+			if err != nil {
+				return err
+			}
 			if fsm.Is(currentState, want) {
 				return next(c)
 			}

--- a/storage.go
+++ b/storage.go
@@ -14,9 +14,9 @@ var ErrNotFound = errors.New("fsm/storage: not found")
 // Not recommended works with storage from handlers.
 type Storage interface {
 	// GetState returns State for target. Default state is empty string
-	GetState(chatId, userId int64) State
+	GetState(chatId, userId int64) (State, error)
 	// SetState sets states for target.
-	SetState(chatId, userId int64, state State)
+	SetState(chatId, userId int64, state State) error
 	// ResetState deletes state for target. If `withData` is true deletes user data from storage.
 	ResetState(chatId, userId int64, withData bool) error
 

--- a/storages/memory/memory.go
+++ b/storages/memory/memory.go
@@ -65,16 +65,17 @@ func (m *Storage) do(key chatKey, call func(*record)) {
 	m.storage[key] = r
 }
 
-func (m *Storage) GetState(chatId, userId int64) fsm.State {
+func (m *Storage) GetState(chatId, userId int64) (fsm.State, error) {
 	m.l.Lock()
 	defer m.l.Unlock()
-	return m.storage[newKey(chatId, userId)].state
+	return m.storage[newKey(chatId, userId)].state, nil
 }
 
-func (m *Storage) SetState(chatId, userId int64, state fsm.State) {
+func (m *Storage) SetState(chatId, userId int64, state fsm.State) error {
 	m.do(newKey(chatId, userId), func(r *record) {
 		r.state = state
 	})
+	return nil
 }
 
 func (m *Storage) ResetState(chatId, userId int64, withData bool) error {


### PR DESCRIPTION
We somehow need to handle errors in the case if a storage implementation (e.g. redis) can't get or set the state because for example the redis instance has been killed, there's no internet connection if the redis instance not on local host etc.

But we even can't get those errors because "GetState" and "SetState" methods of a storage don't return errors.

In the manager and filter I just return those storage errors, but I think we can make something similar to telebot's "bot.OnError" function, where a developer can for example send a message to the user with the text "Something goes wrong, click on /start" if we can't get the state for finding the right handler.


What do you think of that?