### PR TITLE
feat: add file storages

### DIFF
--- a/examples/file_storage/main.go
+++ b/examples/file_storage/main.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/vitaliy-ukiru/fsm-telebot"
+	"github.com/vitaliy-ukiru/fsm-telebot/storages/file"
+	"github.com/vitaliy-ukiru/fsm-telebot/storages/file/provider"
+	tele "gopkg.in/telebot.v3"
+)
+
+const (
+	stateBegin fsm.State = "begin"
+	stateRight fsm.State = "right"
+	stateLeft  fsm.State = "left"
+	stateEnd   fsm.State = "end"
+)
+
+const helpText = `Commands:
+/data <key> - Get data from storage by key
+/set_data <key> <data> - Set data by key
+/begin - Start state travel
+/stop - Stop state travel
+/state - Sends your state
+/complex <float> - Save complex structure to storage
+/snap - Get complex structure from storage`
+
+func main() {
+	log.SetFlags(log.Ltime | log.Lshortfile)
+	storagePath := flag.String(
+		"storage-path",
+		"",
+		"Path to file with data for FSM storage",
+	)
+
+	flag.Parse()
+	if *storagePath == "" {
+		log.Println("setup storage-path command line argument")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	bot, err := tele.NewBot(tele.Settings{
+		Token:  os.Getenv("BOT_TOKEN"),
+		Poller: &tele.LongPoller{Timeout: 3 * time.Second},
+		OnError: func(err error, c tele.Context) {
+			log.Printf("[ERR] %q chat=%s", err, c.Recipient())
+		},
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fsmStorage := file.NewStorage(
+		provider.PrettyJson{
+			JsonSettings: provider.JsonSettings{
+				Indent: "  ",
+			},
+		},
+		file.OpenWriter(*storagePath),
+	)
+
+	{
+		storageFile, err := os.Open(*storagePath)
+		if err == nil {
+			defer storageFile.Close()
+			if err := fsmStorage.Init(storageFile); err != nil {
+				log.Fatalln(err)
+			}
+		}
+	}
+
+	defer func(fsmStorage *file.Storage) {
+		log.Println("saving storage state in Close")
+		err = fsmStorage.Close()
+		if err != nil {
+			log.Print("close storage error: ", err)
+		}
+	}(fsmStorage)
+
+	m := fsm.NewManager(bot, nil, fsmStorage, nil)
+	m.Group().Handle("/help", func(c tele.Context) error {
+		return c.Send(helpText)
+	})
+	m.Bind("/data", fsm.DefaultState, GetDataHandler)
+	m.Bind("/set_data", fsm.DefaultState, SetDataHandler)
+
+	m.Bind("/begin", fsm.DefaultState, CommandBegin)
+
+	m.Bind("/right", stateBegin, CommandRight)
+	m.Bind(tele.OnText, stateRight, RevertMessageText)
+
+	m.Bind("/left", stateBegin, CommandLeft)
+	m.Bind(tele.OnText, stateLeft, UpperMessageText)
+
+	m.Handle(fsm.F("/end", stateRight, stateLeft), CommandEnd)
+	m.Bind("/complex", fsm.AnyState, CommandComplex)
+	m.Bind("/snap", fsm.AnyState, CommandSnap)
+
+	m.Bind("/stop", fsm.AnyState, func(c tele.Context, state fsm.Context) error {
+		if err := state.Finish(false); err != nil {
+			return sendErr(c, err)
+		}
+
+		return c.Send("You stop state")
+	})
+
+	m.Bind("/state", fsm.AnyState, func(c tele.Context, state fsm.Context) error {
+		userState, err := state.State()
+		if err != nil {
+			return sendErr(c, err)
+		}
+		return c.Send("Your state: " + userState.GoString())
+	})
+
+	log.Println("bot stated")
+	go bot.Start()
+
+	{
+		stopChan := make(chan os.Signal, 1)
+		signal.Notify(stopChan, os.Interrupt, os.Kill, syscall.SIGINT, syscall.SIGTERM)
+		<-stopChan
+	}
+
+	// This operation too longs (~4 sec.)
+	// Don't wait in example.
+	// But in production code I think better don't use goroutine
+	go bot.Stop()
+	log.Println("bot stopped")
+
+}
+
+func GetDataHandler(c tele.Context, state fsm.Context) error {
+	key := c.Message().Payload
+	if key == "" {
+		return c.Send("Send key after command. Like /data my_key")
+	}
+	var data string
+	if err := state.Get(key, &data); err != nil {
+		if errors.Is(err, fsm.ErrNotFound) {
+			return c.Send("Not found data in my storage :(")
+		}
+		return sendErr(c, err)
+	}
+	return c.Send("Your data: <code>"+data+"</code>", tele.ModeHTML)
+}
+
+func SetDataHandler(c tele.Context, state fsm.Context) error {
+	args := strings.SplitN(c.Message().Payload, " ", 2)
+	if len(args) < 2 {
+		return c.Send("Ops. You must input two args. Like /set_data my_key my_data")
+	}
+
+	if err := state.Update(args[0], args[1]); err != nil {
+		return sendErr(c, err)
+	}
+
+	return c.Send("I save it!")
+}
+
+func CommandBegin(c tele.Context, state fsm.Context) error {
+	if err := state.Set(stateBegin); err != nil {
+		return sendErr(c, err)
+	}
+
+	return c.Send("Select next step: /right or /left")
+}
+
+func CommandRight(c tele.Context, state fsm.Context) error {
+	if err := state.Set(stateRight); err != nil {
+		return sendErr(c, err)
+	}
+
+	return c.Send("Select next step: /end\nOr send me text and I'm reverse it.")
+}
+
+func RevertMessageText(c tele.Context, _ fsm.Context) error {
+	var sb strings.Builder
+	text := []rune(c.Text()) // for support unicode
+	for i := len(text) - 1; i >= 0; i-- {
+		sb.WriteRune(text[i])
+	}
+	return c.Send(sb.String())
+}
+
+func CommandLeft(c tele.Context, state fsm.Context) error {
+	if err := state.Set(stateLeft); err != nil {
+		return sendErr(c, err)
+	}
+
+	return c.Send("Select next step: /end\nOr send me text and I'm upper it")
+}
+
+func UpperMessageText(c tele.Context, _ fsm.Context) error {
+	return c.Send(strings.ToUpper(c.Text()))
+
+}
+
+func CommandEnd(c tele.Context, state fsm.Context) error {
+	if err := state.Set(stateEnd); err != nil {
+		return sendErr(c, err)
+	}
+
+	return c.Send("Select step: /right or /left\nOr send /stop for end travel.")
+}
+
+type snap struct {
+	Now   time.Time `json:"now	"`
+	User  int64     `json:"user,omitempty"`
+	Input float64   `json:"input,omitempty"`
+}
+
+func CommandComplex(c tele.Context, state fsm.Context) error {
+	float, err := strconv.ParseFloat(c.Message().Payload, 64)
+	if err != nil {
+		return c.Send(err.Error())
+	}
+	s := snap{
+		Now:   time.Now(),
+		User:  c.Sender().ID,
+		Input: float,
+	}
+	if err := state.Update("snap", s); err != nil {
+		return c.Send(err.Error())
+	}
+	return c.Send("saved")
+}
+
+func CommandSnap(c tele.Context, state fsm.Context) error {
+	var s snap
+	if err := state.Get("snap", &s); err != nil {
+		return c.Send(err.Error())
+	}
+	return c.Send(fmt.Sprintf("%+v", s))
+}
+
+func sendErr(c tele.Context, err error) error {
+	return c.Send("error: " + err.Error())
+}

--- a/storages/file/export.go
+++ b/storages/file/export.go
@@ -1,0 +1,93 @@
+package file
+
+import "github.com/vitaliy-ukiru/fsm-telebot"
+
+type (
+	// ChatsStorage in intermediate representation for data in Storage.
+	// This type using simple type for key.
+	// In any way you can create you custom type and custom provider
+	// with compatibility to this type.
+	ChatsStorage map[ChatID]UsersStorage
+	UsersStorage map[UserID]Record
+	Record       struct {
+		State string            `json:"state"`
+		Data  map[string][]byte `json:"data"`
+	}
+
+	ChatID = int64
+	UserID = int64
+)
+
+func (d *dataCache) export(p Provider) ([]byte, error) {
+	if d.raw != nil {
+		return d.raw, nil
+	}
+	bytes, err := p.Encode(d.loaded)
+	if err != nil {
+		return nil, err
+	}
+	d.raw = bytes
+	return bytes, nil
+
+}
+
+func (r *record) exportData(p Provider) (map[string][]byte, error) {
+	if len(r.data) < 1 {
+		return nil, nil
+	}
+
+	m := make(map[string][]byte)
+	for k, d := range r.data {
+		data, err := d.export(p)
+		if err != nil {
+			return nil, err
+		}
+		m[k] = data
+	}
+
+	return m, nil
+}
+
+func (s *Storage) dump() (ChatsStorage, error) {
+	s.rw.RLock()
+	defer s.rw.RUnlock()
+
+	chats := make(ChatsStorage)
+	for key, r := range s.data {
+		chat, ok := chats[key.c]
+		if !ok {
+			chat = make(UsersStorage)
+		}
+
+		exportData, err := r.exportData(s.p)
+		if err != nil {
+			return nil, err
+		}
+
+		chat[key.u] = Record{
+			State: string(r.state),
+			Data:  exportData,
+		}
+		chats[key.c] = chat
+	}
+	return chats, nil
+}
+
+func (s *Storage) reset(dump ChatsStorage) {
+	s.rw.Lock()
+	defer s.rw.Unlock()
+
+	for chatId, usersStorage := range dump {
+		for userId, r := range usersStorage {
+			data := make(map[string]dataCache)
+			for key, d := range r.Data {
+				data[key] = dataCache{raw: d}
+			}
+
+			s.data[newKey(chatId, userId)] = record{
+				state: fsm.State(r.State),
+				data:  data,
+			}
+		}
+	}
+}

--- a/storages/file/file.go
+++ b/storages/file/file.go
@@ -1,0 +1,152 @@
+package file
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/vitaliy-ukiru/fsm-telebot"
+)
+
+type WriterFunc func() (io.WriteCloser, error)
+
+// Provider saves data to files (or streams). With custom format.
+// Some providers (json, gob, base64) are already implemented in
+// the `provider` sub-package
+type Provider interface {
+	ProviderName() string
+	Save(w io.Writer, data ChatsStorage) error
+	Read(r io.Reader) (ChatsStorage, error)
+	Encode(v interface{}) ([]byte, error)
+	Decode(data []byte, v interface{}) error
+}
+
+// chatKey represents  pair {c: chat id, u: user id}
+type chatKey struct {
+	c, u int64
+}
+
+func newKey(chat, user int64) chatKey {
+	return chatKey{
+		c: chat,
+		u: user,
+	}
+}
+
+type record struct {
+	state fsm.State
+	data  map[string]dataCache
+}
+
+// dataCache stores data in two variants.
+// Decoded in loaded
+// and raw.
+type dataCache struct {
+	// loaded decoded content from raw via provider
+	// see dataCache.get in ./internal
+	loaded interface{}
+	// raw content from file.
+	raw []byte
+}
+
+// Storage is storage based on RAM. Drops if you stop script.
+type Storage struct {
+	rw       sync.RWMutex
+	data     map[chatKey]record
+	p        Provider
+	writerFn WriterFunc
+}
+
+func NewStorage(p Provider, writerFn WriterFunc) *Storage {
+	return &Storage{p: p, writerFn: writerFn, data: make(map[chatKey]record)}
+}
+
+func (s *Storage) Init(r io.Reader) error {
+	if r == nil {
+		return nil
+	}
+	dump, err := s.p.Read(r)
+	if err != nil {
+		return err
+	}
+	s.reset(dump)
+	return nil
+}
+
+func (s *Storage) GetState(chatId, userId int64) (fsm.State, error) {
+	s.rw.RLock()
+	defer s.rw.RUnlock()
+	return s.data[newKey(chatId, userId)].state, nil
+}
+
+func (s *Storage) SetState(chatId, userId int64, state fsm.State) error {
+	s.do(chatId, userId, func(r *record) {
+		r.state = state
+	})
+	return nil
+}
+
+func (s *Storage) ResetState(chatId, userId int64, withData bool) error {
+	s.do(chatId, userId, func(r *record) {
+		r.state = ""
+		if withData {
+			r.resetData()
+		}
+	})
+	return nil
+}
+
+func (s *Storage) UpdateData(chatId, userId int64, key string, data interface{}) error {
+	s.do(chatId, userId, func(r *record) {
+		r.updateData(key, data)
+	})
+	return nil
+}
+
+func (s *Storage) GetData(chatId, userId int64, key string, to interface{}) error {
+	s.rw.RLock()
+	defer s.rw.RUnlock()
+	d, ok := s.data[newKey(chatId, userId)].data[key]
+	if !ok {
+		return fsm.ErrNotFound
+	}
+
+	return d.get(to, s.p)
+}
+
+func (s *Storage) Close() error {
+	w, err := s.writerFn()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	if err := s.save(w); err != nil {
+		return err
+	}
+	return w.Close()
+}
+
+func (s *Storage) SaveTo(w io.Writer) error {
+	return s.save(w)
+}
+
+func (s *Storage) save(w io.Writer) error {
+	dump, err := s.dump()
+	if err != nil {
+		return err
+	}
+
+	return s.p.Save(w, dump)
+}
+
+type ProviderError struct {
+	ProviderType string
+	Operation    string
+	Err          error
+}
+
+func (e ProviderError) Unwrap() error { return e.Err }
+func (e ProviderError) Error() string {
+	return fmt.Sprintf("fsm-telebot/storage/file/provider: %s: %s: %v", e.ProviderType, e.Operation, e.Err)
+}

--- a/storages/file/internal.go
+++ b/storages/file/internal.go
@@ -1,0 +1,64 @@
+package file
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+func (r *record) updateData(key string, data interface{}) {
+	if r.data == nil {
+		r.data = make(map[string]dataCache)
+	}
+	if data == nil {
+		delete(r.data, key)
+	} else {
+		r.data[key] = dataCache{loaded: data}
+	}
+}
+
+func (r *record) resetData() {
+	for key := range r.data {
+		delete(r.data, key)
+	}
+}
+
+// do exec `call` and save modification to storage.
+// It helps not to copy the code.
+func (s *Storage) do(chat, user int64, call func(*record)) {
+	s.rw.Lock()
+	defer s.rw.Unlock()
+	key := newKey(chat, user)
+
+	r := s.data[key]
+	call(&r)
+	s.data[key] = r
+}
+
+// get value from data. Priority on loaded value.
+func (d *dataCache) get(to interface{}, p Provider) error {
+	destValue := reflect.ValueOf(to)
+	if destValue.Kind() != reflect.Pointer {
+		return errors.New("dest argument must be pointer")
+	}
+
+	destElem := destValue.Elem()
+	destType := destElem.Type()
+
+	if d.loaded != nil {
+		vType := reflect.TypeOf(d.loaded)
+		if !vType.AssignableTo(destType) {
+			return fmt.Errorf("wrong types, can't assign %s to %s", vType, destType)
+		}
+
+		destElem.Set(reflect.ValueOf(d.loaded))
+		return nil
+	}
+
+	if err := p.Decode(d.raw, to); err != nil {
+		return err
+	}
+
+	d.loaded = destElem.Interface()
+	return nil
+}

--- a/storages/file/provider/base64.go
+++ b/storages/file/provider/base64.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	b64 "encoding/base64"
+	"io"
+
+	"github.com/vitaliy-ukiru/fsm-telebot/storages/file"
+)
+
+// Base64 provides access to two encoded values.
+// This provides might work in network.
+//
+// For example, how this works with Json
+// In first json encoder marshal to json, and writes result to base64 stream
+// and bas64 stream writes to io.Writer.
+type Base64 struct {
+	enc  *b64.Encoding
+	base file.Provider
+}
+
+func NewBase64(enc *b64.Encoding, base file.Provider) *Base64 {
+	return &Base64{enc: enc, base: base}
+}
+
+func (b Base64) Encode(v interface{}) ([]byte, error) {
+	src, err := b.base.Encode(v)
+	if err != nil {
+		return nil, newError("base64", "encode", err)
+	}
+
+	buff := make([]byte, b.enc.EncodedLen(len(src)))
+	b.enc.Encode(buff, src)
+	return buff, nil
+}
+
+func (b Base64) Decode(data []byte, v interface{}) error {
+	buff := make([]byte, b.enc.DecodedLen(len(data)))
+	n, err := b.enc.Decode(buff, data)
+	if err != nil {
+		return newError("base64", "decode base64", err)
+	}
+	buff = buff[:n]
+	err = b.base.Decode(buff, v)
+	return newError("base64", "decode", err)
+}
+
+func (b Base64) ProviderName() string {
+	return "base64:" + b.base.ProviderName()
+}
+
+func (b Base64) Save(w io.Writer, data file.ChatsStorage) error {
+	encoder := b64.NewEncoder(b.enc, w)
+	defer encoder.Close()
+
+	if err := b.base.Save(encoder, data); err != nil {
+		return newError("base64", "save", err)
+	}
+	return newError("base64", "save:close", encoder.Close())
+}
+
+func (b Base64) Read(r io.Reader) (file.ChatsStorage, error) {
+	d := b64.NewDecoder(b.enc, r)
+	cs, err := b.base.Read(d)
+	if err != nil {
+		return nil, newError("base64", "read", err)
+	}
+	return cs, nil
+}

--- a/storages/file/provider/doc.go
+++ b/storages/file/provider/doc.go
@@ -1,0 +1,5 @@
+// Package provider contains providers for formats:
+//   - encoding/gob (Gob)
+//   - encoding/json (Json and PrettyJson)
+//   - wrapped base64 (Base64 see docs for details)
+package provider

--- a/storages/file/provider/error.go
+++ b/storages/file/provider/error.go
@@ -1,0 +1,10 @@
+package provider
+
+import "github.com/vitaliy-ukiru/fsm-telebot/storages/file"
+
+func newError(provider string, op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &file.ProviderError{ProviderType: provider, Operation: op, Err: err}
+}

--- a/storages/file/provider/gob.go
+++ b/storages/file/provider/gob.go
@@ -1,0 +1,47 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/gob"
+	"io"
+
+	"github.com/vitaliy-ukiru/fsm-telebot/storages/file"
+)
+
+// Gob provides encoding/gob format.
+// Zero value is safe.
+type Gob struct{}
+
+func NewGob() *Gob {
+	return &Gob{}
+}
+
+func (Gob) ProviderName() string { return "gob" }
+
+func (Gob) Encode(v interface{}) ([]byte, error) {
+	buff := new(bytes.Buffer)
+	if err := gob.NewEncoder(buff).Encode(v); err != nil {
+		return nil, newError("gob", "encode", err)
+	}
+	return buff.Bytes(), nil
+}
+
+func (Gob) Decode(data []byte, to interface{}) error {
+	buff := bytes.NewReader(data)
+	return newError("gob", "decode", gob.NewDecoder(buff).Decode(to))
+}
+
+func (Gob) Save(w io.Writer, data file.ChatsStorage) error {
+	e := gob.NewEncoder(w)
+	err := e.Encode(data)
+	return newError("gob", "save", err)
+}
+
+func (g Gob) Read(r io.Reader) (file.ChatsStorage, error) {
+	d := gob.NewDecoder(r)
+	var dest file.ChatsStorage
+	if err := d.Decode(&dest); err != nil {
+		return nil, newError("gob", "read", err)
+	}
+	return dest, nil
+}

--- a/storages/file/provider/json.go
+++ b/storages/file/provider/json.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/vitaliy-ukiru/fsm-telebot/storages/file"
+)
+
+// JsonSettings configures json encoder and decoder.
+// Un export fields will be ignoring (json package behavior)
+// Zero value configures as default json.Encoder and json.Decoder.
+type JsonSettings struct {
+	Prefix                string
+	Indent                string
+	UseNumber             bool
+	DisallowUnknownFields bool
+}
+
+// Json provides json format.
+type Json struct {
+	JsonSettings
+}
+
+func NewJson(jsonSettings JsonSettings) *Json {
+	return &Json{JsonSettings: jsonSettings}
+}
+
+func (j Json) Encode(v interface{}) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, newError("json", "encode", err)
+	}
+	return data, nil
+}
+
+func (j Json) Decode(data []byte, v interface{}) error {
+	return newError("json", "decode", json.Unmarshal(data, v))
+}
+
+func (j Json) ProviderName() string { return "json" }
+
+func (j Json) Save(w io.Writer, data file.ChatsStorage) error {
+	e := json.NewEncoder(w)
+	e.SetIndent(j.Prefix, j.Indent)
+
+	err := e.Encode(data)
+	return newError("json", "save", err)
+}
+func (j Json) Read(r io.Reader) (file.ChatsStorage, error) {
+	d := json.NewDecoder(r)
+
+	if j.DisallowUnknownFields {
+		d.DisallowUnknownFields()
+	}
+
+	if j.UseNumber {
+		d.UseNumber()
+	}
+	var dest file.ChatsStorage
+	if err := d.Decode(&dest); err != nil {
+		return nil, newError("json", "read", err)
+	}
+	return dest, nil
+}

--- a/storages/file/provider/middleware.go
+++ b/storages/file/provider/middleware.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"io"
+
+	"github.com/vitaliy-ukiru/fsm-telebot/storages/file"
+)
+
+type Callbacks struct {
+	OnSave   func(p file.Provider, w io.Writer, data file.ChatsStorage) error
+	OnRead   func(p file.Provider, r io.Reader) (file.ChatsStorage, error)
+	OnEncode func(p file.Provider, v interface{}) ([]byte, error)
+	OnDecode func(p file.Provider, data []byte, v interface{}) error
+}
+
+// Middleware adds functional for middlewares in file.Provider
+// Middlewares callbacks controls flow.
+// It means what in callback you execute provider function
+// Example
+//
+//	var p file.Provider
+//	m := NewMiddleware(p, Callbacks{
+//		OnEncode: func(p file.Provider, v interface{}) ([]byte, error) {
+//			// actions before encoding
+//			data, err := p.Encode(v)
+//			// actions after encoding
+//			// for example
+//			log.Printf("encode value of type: %T; result=%s, err=%v", v, data, err)
+//			return data, err
+//		},
+//	})
+//
+// If callback not exists for method will call raw provider.
+// ADDED AS EXPERIMENT, PREFER DON'T USE IN PRODUCTION.
+type Middleware struct {
+	p file.Provider
+	c Callbacks
+}
+
+func NewMiddleware(p file.Provider, c Callbacks) *Middleware {
+	return &Middleware{p: p, c: c}
+}
+
+// Merge only non nil callbacks.
+func (m *Middleware) Merge(c Callbacks) {
+	if c.OnSave != nil {
+		m.c.OnSave = c.OnSave
+	}
+
+	if c.OnRead != nil {
+		m.c.OnRead = c.OnRead
+	}
+
+	if c.OnEncode != nil {
+		m.c.OnEncode = c.OnEncode
+	}
+
+	if c.OnDecode != nil {
+		m.c.OnDecode = c.OnDecode
+	}
+}
+
+func (m Middleware) ProviderName() string {
+	return m.p.ProviderName()
+}
+
+func (m Middleware) Save(w io.Writer, data file.ChatsStorage) error {
+	fn := file.Provider.Save
+	if c := m.c.OnSave; c != nil {
+		fn = c
+	}
+	return fn(m.p, w, data)
+}
+
+func (m Middleware) Read(r io.Reader) (file.ChatsStorage, error) {
+	fn := file.Provider.Read
+	if c := m.c.OnRead; c != nil {
+		fn = c
+	}
+	return fn(m.p, r)
+}
+
+func (m Middleware) Encode(v interface{}) ([]byte, error) {
+	fn := file.Provider.Encode
+	if c := m.c.OnEncode; c != nil {
+		fn = c
+	}
+	return fn(m.p, v)
+}
+
+func (m Middleware) Decode(data []byte, v interface{}) error {
+	fn := file.Provider.Decode
+	if c := m.c.OnDecode; c != nil {
+		fn = c
+	}
+	return fn(m.p, data, v)
+}

--- a/storages/file/provider/pretty_json.go
+++ b/storages/file/provider/pretty_json.go
@@ -1,0 +1,177 @@
+package provider
+
+import (
+	"bytes"
+	b64 "encoding/base64"
+	"encoding/json"
+	"io"
+
+	"github.com/vitaliy-ukiru/fsm-telebot/storages/file"
+)
+
+// PrettyJson provides json format with pretty encoding data values (file.Record Data fields).
+// Default json package encodes []byte as base64 string.
+// This provider allows use json.RawMessage. But it's not free.
+// The structure is copied to the new one to keep the data safe.
+//
+// The provider allows you to add indentation to the Encode method
+// using the IndentInEncodeMethod flag.
+//
+// Use TryDecodeBase64String to try to decode base64 strings
+// (try to backward compatibility with Json).
+//
+// But the package does not take responsibility for decoding strings
+// if you use base64 for your own purposes.
+//
+// Un export fields will be ignoring (json package behavior)
+type PrettyJson struct {
+	JsonSettings
+
+	// TryDecodeBase64String tries to decode strings from base64.
+	TryDecodeBase64String bool
+
+	// IndentInEncodeMethod adds Indent in Encode.
+	// If Indent is set when Save is called, the indent
+	// will be added regardless of this parameter
+	IndentInEncodeMethod bool
+}
+
+func NewPrettyJson(jsonSettings JsonSettings, tryDecodeBase64String bool, indentInEncodeMethod bool) *PrettyJson {
+	return &PrettyJson{JsonSettings: jsonSettings, TryDecodeBase64String: tryDecodeBase64String, IndentInEncodeMethod: indentInEncodeMethod}
+}
+
+const prettyJson = "pretty_json"
+
+func (j PrettyJson) ProviderName() string { return prettyJson }
+
+func (j PrettyJson) Encode(v interface{}) ([]byte, error) {
+	buff := new(bytes.Buffer)
+
+	e := json.NewEncoder(buff)
+	if j.IndentInEncodeMethod {
+		e.SetIndent("", j.Indent)
+	}
+
+	if err := e.Encode(v); err != nil {
+		return nil, newError(prettyJson, "encode", err)
+	}
+	return buff.Bytes(), nil
+}
+
+func (j PrettyJson) Decode(data []byte, v interface{}) error {
+	buff := bytes.NewReader(data)
+
+	d := json.NewDecoder(buff)
+	if j.DisallowUnknownFields {
+		d.DisallowUnknownFields()
+	}
+
+	if j.UseNumber {
+		d.UseNumber()
+	}
+	return newError(prettyJson, "decode", d.Decode(v))
+}
+
+func (j PrettyJson) Save(w io.Writer, data file.ChatsStorage) error {
+	buff := new(bytes.Buffer)
+	e := json.NewEncoder(buff)
+
+	storage := j.convertTo(data)
+	if err := e.Encode(storage); err != nil {
+		return newError(prettyJson, "save encode", err)
+	}
+	if j.Indent != "" {
+		// copy buffer because will reuse buffer resources
+		compact := make([]byte, buff.Len())
+		copy(compact, buff.Bytes())
+		buff.Reset()
+		if err := json.Indent(buff, compact, j.Prefix, j.Indent); err != nil {
+			return newError(prettyJson, "save prettify", err)
+		}
+	}
+
+	_, err := buff.WriteTo(w)
+	return newError(prettyJson, "save", err)
+
+}
+
+func (j PrettyJson) Read(r io.Reader) (file.ChatsStorage, error) {
+	d := json.NewDecoder(r)
+
+	if j.DisallowUnknownFields {
+		d.DisallowUnknownFields()
+	}
+
+	if j.UseNumber {
+		d.UseNumber()
+	}
+	var dest jsonStorage
+	if err := d.Decode(&dest); err != nil {
+		return nil, newError(prettyJson, "read", err)
+	}
+	return j.convertFrom(dest), nil
+}
+
+type jsonStorage map[int64]map[int64]record
+type record struct {
+	State string                     `json:"state"`
+	Data  map[string]json.RawMessage `json:"data"`
+}
+
+func (j PrettyJson) tryDecodeB64(enc *b64.Encoding, src []byte) ([]byte, bool) {
+	if src[0] != '"' && src[len(src)-1] != '"' {
+		return nil, false
+	}
+
+	src = src[1 : len(src)-1]
+	buf := make([]byte, enc.DecodedLen(len(src)))
+	n, err := enc.Decode(buf, src)
+	if err != nil {
+		return nil, false
+	}
+	return buf[:n], true
+}
+
+func (j PrettyJson) convertTo(storage file.ChatsStorage) jsonStorage {
+	result := make(jsonStorage)
+	for chatId, usersStorage := range storage {
+		usersData := make(map[int64]record)
+		for userId, r := range usersStorage {
+			data := make(map[string]json.RawMessage)
+			for key, raw := range r.Data {
+				data[key] = raw
+			}
+			usersData[userId] = record{
+				State: r.State,
+				Data:  data,
+			}
+		}
+		result[chatId] = usersData
+	}
+	return result
+}
+
+func (j PrettyJson) convertFrom(storage jsonStorage) file.ChatsStorage {
+	result := make(file.ChatsStorage)
+	for chatId, usersStorage := range storage {
+		usersData := make(file.UsersStorage)
+		for userId, r := range usersStorage {
+			data := make(map[string][]byte)
+			for key, raw := range r.Data {
+				if j.TryDecodeBase64String {
+					decoded, ok := j.tryDecodeB64(b64.StdEncoding, raw)
+					if ok {
+						raw = decoded
+					}
+				}
+				data[key] = raw
+			}
+			usersData[userId] = file.Record{
+				State: r.State,
+				Data:  data,
+			}
+		}
+		result[chatId] = usersData
+	}
+	return result
+}

--- a/storages/file/utils.go
+++ b/storages/file/utils.go
@@ -1,0 +1,40 @@
+package file
+
+import (
+	"io"
+	"os"
+)
+
+func OpenWriter(filename string) WriterFunc {
+	return func() (io.WriteCloser, error) {
+		return os.Create(filename)
+	}
+}
+
+func OpenFileCache(filename string) WriterFunc {
+	file, err := os.Create(filename)
+	return func() (io.WriteCloser, error) {
+		return file, err
+	}
+}
+
+func ExistsWriter(w io.WriteCloser) WriterFunc {
+	return func() (io.WriteCloser, error) {
+		return w, nil
+	}
+}
+
+// OpenReaderFile opens file for read.
+// If file not exists will return nil values. OldFileStorage supported this case (see OldFileStorage.Init).
+// Also function returns io.ReadCloser for closing file in user code.
+func OpenReaderFile(path string) (io.ReadCloser, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+
+		}
+		return nil, err
+	}
+	return file, nil
+}


### PR DESCRIPTION
Adds universal format file storage based on in-memory storage.
During operation it stores data in a structure similar to memory.Storage.  The difference is in data storage (Storage.GetData, Storage.UpdateData). 
To be able to save data into structures from provider formats, the structure storing a unit of information looks like this: 

```go 
// from storages/file/file.go


type dataCache struct {
        // loaded decoded content from raw via provider
       loaded interface{}
        // raw content from file.
	raw []byte 
} 
``` 

The `raw` field stores the value obtained during storage recovery. The `loaded` field stores the value obtained by the `Provider.Decode` method after the first data retrieval or the value set via `FileStorage.UpdateData`.  When saving to a file, the last state will always be stored (behavior `record.updateData`). 

This solution is a compromise between preserving type functionality and speed of operation, because it is more overhead to decode each time when receiving data.
 However, the operation of saving data to a file is more overhead, because the value is encoded twice.