### PR TITLE
Feat: add state match func

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -1,6 +1,8 @@
 package fsm
 
 import (
+	"strings"
+
 	tele "gopkg.in/telebot.v3"
 )
 
@@ -39,7 +41,11 @@ func (m *Manager) TelebotHandlerForStates(h Handler, states ...State) tele.Handl
 }
 
 func (f Filter) CallbackUnique() string {
-	switch end := f.Endpoint.(type) {
+	return callbackUnique(f.Endpoint)
+}
+
+func callbackUnique(endpoint interface{}) string {
+	switch end := endpoint.(type) {
 	case string:
 		return end
 	case tele.CallbackEndpoint:
@@ -47,4 +53,18 @@ func (f Filter) CallbackUnique() string {
 	default:
 		panic("fsm: telebot: unsupported endpoint")
 	}
+}
+
+// PrefixFilter filters state on have prefix
+// with separated symbol.
+func PrefixFilter(prefix string) StateMatchFunc {
+	prefix = prefix + "@"
+	return func(state State) bool {
+		return strings.HasPrefix(string(state), prefix)
+	}
+}
+
+// MatchAnyState matches any state.
+func MatchAnyState(_ State) bool {
+	return true
 }

--- a/manager.go
+++ b/manager.go
@@ -83,6 +83,22 @@ func (m *Manager) Use(middlewares ...tele.MiddlewareFunc) {
 	m.group.Use(middlewares...)
 }
 
+// StateMatchFunc matches state for handler.
+// The function must handle the AnyState case custom.
+// Package won't call with AnyState argument.
+type StateMatchFunc func(state State) bool
+
+// BindFunc binds handler with matchFunc as checker.
+func (m *Manager) BindFunc(end interface{}, matchFunc StateMatchFunc, h Handler, middlewares ...tele.MiddlewareFunc) {
+	endpoint := callbackUnique(end)
+	m.handlers.addFunc(endpoint, h, matchFunc)
+	m.group.Handle(
+		endpoint,
+		m.HandlerAdapter(m.handlers.forEndpoint(endpoint)),
+		middlewares...,
+	)
+}
+
 // Bind adds handler (with FSMContext) with filter on state.
 //
 // Difference between Bind and Handle methods what Handle require Filter objects.


### PR DESCRIPTION
Adds functional for using function as state filter.
This feature compability with states set (default variant).
Steps:

- [x]  Create internal support of match function
- [x] Create public API 
- [x] Create some builtins filters
- [ ] Create example program with use match function
- [ ] Review idea