### PR TITLE
feat: add support for groups with compatibility with fsm handlers

### DIFF
--- a/group.go
+++ b/group.go
@@ -1,0 +1,36 @@
+package fsm
+
+import tele "gopkg.in/telebot.v3"
+
+// Group is copy of tele.Group but with support FSM handlers.
+// If you use tele.Group then handlers will override by telebot.
+// And you can get bugs.
+type Group struct {
+	m           *Manager
+	middlewares []tele.MiddlewareFunc
+}
+
+func (g *Group) Use(middlewares ...tele.MiddlewareFunc) {
+	g.middlewares = append(g.middlewares, middlewares...)
+}
+
+func (g *Group) with(m []tele.MiddlewareFunc) []tele.MiddlewareFunc {
+	return append(g.middlewares, m...)
+}
+
+func (g *Group) Copy() *Group {
+	copyMiddlewares := make([]tele.MiddlewareFunc, len(g.middlewares))
+	copy(copyMiddlewares, g.middlewares)
+	return &Group{
+		m:           g.m,
+		middlewares: copyMiddlewares,
+	}
+}
+
+func (g *Group) Bind(end interface{}, state State, h Handler, middlewares ...tele.MiddlewareFunc) {
+	g.m.Bind(end, state, h, g.with(middlewares)...)
+}
+
+func (g *Group) Handle(f Filter, h Handler, middlewares ...tele.MiddlewareFunc) {
+	g.m.Handle(f, h, g.with(middlewares)...)
+}

--- a/manager.go
+++ b/manager.go
@@ -78,6 +78,11 @@ func (m *Manager) NewGroup() *Manager {
 	}
 }
 
+// NewFSMGroup creates FSM safe group for using middleware.
+func (m *Manager) NewFSMGroup() *Group {
+	return &Group{m: m}
+}
+
 // Use add middlewares to group.
 func (m *Manager) Use(middlewares ...tele.MiddlewareFunc) {
 	m.group.Use(middlewares...)


### PR DESCRIPTION
Using some telebot groups with some fsm manager - bad idea. Because managers will rewrites  base group.