### PR TITLE
Safe processing updates, without accurate target

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -32,7 +32,11 @@ func (m *Manager) Filter(filter StateMatcher) tf.Filter {
 }
 
 func (m *Manager) runFilter(c tele.Context, filter StateMatcher) bool {
-	fsmCtx := m.mustGetContext(c)
+	fsmCtx, ok := m.mustGetContext(c)
+	// don't run filter if can't get context
+	if !ok || fsmCtx == nil {
+		return false
+	}
 
 	return m.filterProcessor(c, fsmCtx, filter)
 }

--- a/handler.go
+++ b/handler.go
@@ -19,8 +19,11 @@ func (m *Manager) runHandler(c tele.Context, handler Handler) error {
 // FSM will unwrap this context in internal mechanic.
 func (m *Manager) WrapContext(next tele.HandlerFunc) tele.HandlerFunc {
 	return func(c tele.Context) error {
-		ctx := newWrapperContext(c, m.NewContext(c))
-		return next(ctx)
+		fsmCtx, ok := m.NewContext(c)
+		if ok {
+			c = newWrapperContext(c, fsmCtx)
+		}
+		return next(c)
 	}
 }
 

--- a/handler.go
+++ b/handler.go
@@ -20,14 +20,10 @@ func (m *Manager) WrapContext(next tele.HandlerFunc) tele.HandlerFunc {
 	}
 }
 
-type handlerEntity struct {
+type fsmHandler struct {
 	onState StateMatcher
 	filter  tf.Filter
 	handler Handler
-}
-
-type fsmHandler struct {
-	handlerEntity
 	manager *Manager
 }
 

--- a/handler.go
+++ b/handler.go
@@ -6,7 +6,11 @@ import (
 )
 
 func (m *Manager) runHandler(c tele.Context, handler Handler) error {
-	fsmCtx := m.mustGetContext(c)
+	fsmCtx, ok := m.mustGetContext(c)
+	// don't run handler if can't get context
+	if !ok || fsmCtx == nil {
+		return nil
+	}
 	return handler(c, fsmCtx)
 }
 

--- a/internal/null/generic.go
+++ b/internal/null/generic.go
@@ -1,0 +1,11 @@
+package null
+
+type Nullable[T any] struct {
+	Value T
+	Valid bool
+}
+
+func (null *Nullable[T]) Set(value T) {
+	null.Value = value
+	null.Valid = true
+}

--- a/manager.go
+++ b/manager.go
@@ -116,12 +116,12 @@ func (m *Manager) Handle(
 	fn Handler,
 	mw ...tele.MiddlewareFunc,
 ) {
-	entity := handlerEntity{
+	handler := fsmHandler{
 		onState: onState,
 		handler: fn,
 	}
 
-	route := m.newRoute(endpoint, entity, mw)
+	route := m.newRoute(endpoint, handler, mw)
 	dp.Dispatch(route)
 }
 
@@ -131,21 +131,20 @@ func (m *Manager) New(opts ...HandlerOption) tf.Route {
 		opt(hc)
 	}
 
-	entity := handlerEntity{
+	handler := fsmHandler{
 		onState: hc.OnState,
 		filter:  combineFilters(hc.Filters),
 		handler: hc.Handler,
 	}
-	return m.newRoute(hc.Endpoint, entity, hc.Middlewares)
+	return m.newRoute(hc.Endpoint, handler, hc.Middlewares)
 }
 
-func (m *Manager) newRoute(e any, entity handlerEntity, mw []tele.MiddlewareFunc) tf.Route {
+func (m *Manager) newRoute(e any, handler fsmHandler, mw []tele.MiddlewareFunc) tf.Route {
+	handler.manager = m
+
 	return tf.Route{
-		Endpoint: e,
-		Handler: &fsmHandler{
-			handlerEntity: entity,
-			manager:       m,
-		},
+		Endpoint:    e,
+		Handler:     handler,
 		Middlewares: mw,
 	}
 }

--- a/manager.go
+++ b/manager.go
@@ -60,17 +60,23 @@ func New(storage Storage, opts ...ManagerOption) *Manager {
 }
 
 // NewContext creates new FSM Context.
+// Context will create via call context factory.
 //
-// It calls provided ContextFactory.
-func (m *Manager) NewContext(ctx tele.Context) Context {
-	key := ExtractKeyWithStrategy(ctx, m.strategy)
-	return m.contextFactory(m.store, key)
+// If key will be non-present it will return (nil, false)
+func (m *Manager) NewContext(ctx tele.Context) (Context, bool) {
+	key, ok := extractKeyWithStrategy(ctx, m.strategy)
+	if !ok {
+		return nil, false
+	}
+
+	context := m.contextFactory(m.store, key)
+	return context, context != nil
 }
 
-func (m *Manager) mustGetContext(c tele.Context) Context {
+func (m *Manager) mustGetContext(c tele.Context) (Context, bool) {
 	fsmCtx, ok := tryUnwrapContext(c)
 	if ok {
-		return fsmCtx
+		return fsmCtx, fsmCtx != nil
 	}
 	return m.NewContext(c)
 }

--- a/states.go
+++ b/states.go
@@ -34,10 +34,7 @@ func (s State) GoString() string {
 
 // StateGroup storages states with custom prefix.
 //
-// It can use in filter like and handled via Manager.Handle:
-//
-//	group := fsm.NewStateGroup("adm", "State0", "State1")
-//	filter := fsm.F("/cmd", group.States...)
+// This can be used as a filter for the state as [StateMatcher]
 type StateGroup struct {
 	prefix string
 	group  *container.LinkedHashSet[State]

--- a/strategy.go
+++ b/strategy.go
@@ -3,6 +3,7 @@ package fsm
 import (
 	"fmt"
 
+	"github.com/vitaliy-ukiru/fsm-telebot/v2/internal/null"
 	tele "gopkg.in/telebot.v3"
 )
 
@@ -77,11 +78,33 @@ func (s Strategy) Apply(botId int64, chatId int64, userId int64, threadId int64)
 	}
 }
 
-func ExtractKeyWithStrategy(c tele.Context, strategy Strategy) StorageKey {
-	chatId := c.Chat().ID
-	userId := c.Sender().ID
-	threadId := int64(c.Message().ThreadID)
+func extractKeyWithStrategy(c tele.Context, strategy Strategy) (StorageKey, bool) {
+	var (
+		chatId null.Nullable[int64]
+		userId null.Nullable[int64]
+	)
+
+	if chat := c.Chat(); chat != nil {
+		chatId.Set(chat.ID)
+	}
+
+	if user := c.Sender(); user != nil {
+		userId.Set(user.ID)
+	}
+
+	var threadId int64
+	if m := c.Message(); m != nil && m.TopicMessage {
+		threadId = int64(c.Message().ThreadID)
+	}
+
+	if !chatId.Valid {
+		chatId = userId
+	}
+
+	if !chatId.Valid || !userId.Valid {
+		return StorageKey{}, false
+	}
 
 	bot := c.Bot().Me
-	return strategy.Apply(bot.ID, chatId, userId, threadId)
+	return strategy.Apply(bot.ID, chatId.Value, userId.Value, threadId), true
 }


### PR DESCRIPTION
If updates don't have information for extract key this update will be processed as not matched.
This removes the possibility of panic: nil pointer dereference.
Also, it doesn't execute handler with nil FSM context value.